### PR TITLE
vegan::adonis is deprecated, will be defunct: use vegan::adonis2

### DIFF
--- a/vignettes/GCalignR_step_by_step.Rmd
+++ b/vignettes/GCalignR_step_by_step.Rmd
@@ -248,12 +248,12 @@ ggplot(data = scent_nmds,aes(MDS1,MDS2,color = colony)) +
             fill = NA), aspect.ratio = 1, legend.position = "none")
 ```
 
-### Multivariate analysis using *adonis*
-Using **adonis** and **betadisper** we can immediately do multivariate statistics, showing that the two colonies differ significantly. This illustrates a location effect.
+### Multivariate analysis using *adonis2*
+Using **adonis2** and **betadisper** we can immediately do multivariate statistics, showing that the two colonies differ significantly. This illustrates a location effect.
 
 ```{r}
 ## colony effect
-vegan::adonis(scent ~ peak_factors$colony,permutations = 999) 
+vegan::adonis2(scent ~ peak_factors$colony,permutations = 999)
 ## no dispersion effect
 anova(vegan::betadisper(vegan::vegdist(scent),peak_factors$colony))
 ```


### PR DESCRIPTION
Latest vegan release on CRAN deprecated adonis in favour of adonis2. The next major vegan release will make adonis defunct which would trigger an error in your package. vegan::adonis2 has been the recommend choice since vegan 2.6-2 and has bee available since vegan 2.5-7 so that this PR will work also with older version of vegan.